### PR TITLE
Issue 1470 boot splash slow

### DIFF
--- a/lv_conf_templ.h
+++ b/lv_conf_templ.h
@@ -224,15 +224,15 @@
  * 
  * This will allocate a static buffer to store HEIGHT x WIDTH
  * number of pixels.*/
-#define LV_ENABLE_CHARACTER_BUFFER 1
-#if LV_ENABLE_CHARACTER_BUFFER != 0
+#define LV_ENABLE_PIXEL_BUFFER 1
+#if LV_ENABLE_PIXEL_BUFFER != 0
 // Set this to the maximum height x width of any character in your fonts
 #define LV_CHARACTER_MAX_PIX_HEIGHT 40
 #define LV_CHARACTER_MAX_PIX_WIDTH 40
 #if (LV_CHARACTER_MAX_PIX_HEIGHT <= 0) || (LV_CHARACTER_MAX_PIX_WIDTH <= 0)
 #error "Character buffer dimensions must be positive."
 #endif
-#endif /* LV_ENABLE_CHARACTER_BUFFER */
+#endif /* LV_ENABLE_PIXEL_BUFFER */
 
 /*===================
  *  LV_OBJ SETTINGS

--- a/lv_draw/lv_draw_rbasic.c
+++ b/lv_draw/lv_draw_rbasic.c
@@ -305,18 +305,13 @@ void lv_rmap(const lv_area_t * cords_p, const lv_area_t * mask_p,
         for(row = masked_a.y1; row <= masked_a.y2; row++) {
             for(col = masked_a.x1; col <= masked_a.x2; col++) {
                 lv_color_t * px_color = (lv_color_t *) &map_p[(uint32_t)(col - masked_a.x1) * sizeof(lv_color_t)];
-
                 if(chroma_key && chroma_key_color.full == px_color->full) continue;
-
                 if(recolor_opa != LV_OPA_TRANSP) {
                     lv_color_t recolored_px = lv_color_mix(recolor, *px_color, recolor_opa);
-
                     lv_rpx(col, row, mask_p, recolored_px, LV_OPA_COVER);
-                } else {
-                    lv_rpx(col, row, mask_p, *px_color, LV_OPA_COVER);
                 }
-
             }
+            lv_disp_map(row, masked_a.x1, row+1, masked_a.x2, (lv_color_t *)map_p);
             map_p += map_width * sizeof(lv_color_t);               /*Next row on the map*/
         }
     }

--- a/lv_draw/lv_draw_rbasic.c
+++ b/lv_draw/lv_draw_rbasic.c
@@ -31,6 +31,7 @@
 static lv_color_t letter_bg_color;
 #if LV_ENABLE_PIXEL_BUFFER != 0
     static lv_color_t pixel_buffer[LV_CHARACTER_MAX_PIX_HEIGHT * LV_CHARACTER_MAX_PIX_WIDTH];
+    static uint32_t pixel_buffer_size = LV_CHARACTER_MAX_PIX_HEIGHT * LV_CHARACTER_MAX_PIX_WIDTH;
 #endif
 /**********************
  *      MACROS
@@ -306,13 +307,18 @@ void lv_rmap(const lv_area_t * cords_p, const lv_area_t * mask_p,
         bzero(pixel_buffer, sizeof(pixel_buffer));
         for(row = masked_a.y1; row <= masked_a.y2; row++) {
             for(col = masked_a.x1; col <= masked_a.x2; col++) {
+                uint32_t overflow_offset = 0;
                 lv_color_t * px_color = (lv_color_t *) &map_p[(uint32_t)(col - masked_a.x1) * sizeof(lv_color_t)];
                 if(chroma_key && chroma_key_color.full == px_color->full) continue;
+                if((col - masked_a.x1 - overflow_offset) > pixel_buffer_size) {
+                    // here we are going to account for overflow_offset
+                    // and call lv_disp_map() and then continue;
+                }
                 if(recolor_opa != LV_OPA_TRANSP) {
                     lv_color_t recolored_px = lv_color_mix(recolor, *px_color, recolor_opa);
-                    pixel_buffer[col - masked_a.x1] = recolored_px;
+                    pixel_buffer[col - masked_a.x1 - overflow_offset] = recolored_px;
                 } else {
-                    pixel_buffer[col - masked_a.x1] = *px_color;
+                    pixel_buffer[col - masked_a.x1 - overflow_offset] = *px_color;
                 }
             }
             lv_disp_map(row, masked_a.x1, row+1, masked_a.x2, pixel_buffer);

--- a/lv_draw/lv_draw_rbasic.c
+++ b/lv_draw/lv_draw_rbasic.c
@@ -302,16 +302,19 @@ void lv_rmap(const lv_area_t * cords_p, const lv_area_t * mask_p,
     } else {
         lv_color_t chroma_key_color = LV_COLOR_TRANSP;
         lv_coord_t col;
+        lv_color_t img_buffer[masked_a.x2 - masked_a.x1];
         for(row = masked_a.y1; row <= masked_a.y2; row++) {
             for(col = masked_a.x1; col <= masked_a.x2; col++) {
                 lv_color_t * px_color = (lv_color_t *) &map_p[(uint32_t)(col - masked_a.x1) * sizeof(lv_color_t)];
                 if(chroma_key && chroma_key_color.full == px_color->full) continue;
                 if(recolor_opa != LV_OPA_TRANSP) {
                     lv_color_t recolored_px = lv_color_mix(recolor, *px_color, recolor_opa);
-                    lv_rpx(col, row, mask_p, recolored_px, LV_OPA_COVER);
+                    img_buffer[col - masked_a.x1] = recolored_px;
+                } else {
+                    img_buffer[col - masked_a.x1] = *px_color;
                 }
             }
-            lv_disp_map(row, masked_a.x1, row+1, masked_a.x2, (lv_color_t *)map_p);
+            lv_disp_map(row, masked_a.x1, row+1, masked_a.x2, img_buffer);
             map_p += map_width * sizeof(lv_color_t);               /*Next row on the map*/
         }
     }

--- a/lv_draw/lv_draw_rbasic.c
+++ b/lv_draw/lv_draw_rbasic.c
@@ -29,7 +29,9 @@
  *  STATIC VARIABLES
  **********************/
 static lv_color_t letter_bg_color;
-
+#if LV_ENABLE_CHARACTER_BUFFER != 0
+    static lv_color_t pixel_buffer[LV_CHARACTER_MAX_PIX_HEIGHT * LV_CHARACTER_MAX_PIX_WIDTH];
+#endif
 /**********************
  *      MACROS
  **********************/
@@ -121,7 +123,6 @@ void lv_rletter(const lv_point_t * pos_p, const lv_area_t * mask_p,
     uint8_t mask;
 
 #if LV_ENABLE_CHARACTER_BUFFER != 0
-    lv_color_t letter_img[LV_CHARACTER_MAX_PIX_HEIGHT * LV_CHARACTER_MAX_PIX_WIDTH];
 
     // Make sure letter dimensions don't exceed the size of our character buffer
     letter_h = (letter_h > LV_CHARACTER_MAX_PIX_HEIGHT) ? LV_CHARACTER_MAX_PIX_HEIGHT : letter_h;
@@ -195,11 +196,11 @@ void lv_rletter(const lv_point_t * pos_p, const lv_area_t * mask_p,
                 isWhitespace = false;
             }
 #else
-                letter_img[(col-col_start)*letter_h + (row-row_start)] = lv_color_mix(color, letter_bg_color, bpp == 8 ? letter_px : bpp_opa_table[letter_px]);
+                pixel_buffer[(col-col_start)*letter_h + (row-row_start)] = lv_color_mix(color, letter_bg_color, bpp == 8 ? letter_px : bpp_opa_table[letter_px]);
                 zeroRow[row] = 0;
                 isWhitespace = false;
             } else {
-                letter_img[(col-col_start)*letter_h + (row-row_start)] = letter_bg_color;
+                pixel_buffer[(col-col_start)*letter_h + (row-row_start)] = letter_bg_color;
             }
 #endif
             if(col_bit < 8 - bpp) {
@@ -241,14 +242,14 @@ void lv_rletter(const lv_point_t * pos_p, const lv_area_t * mask_p,
     uint16_t k = 0;
     for(col = col_start; col < col_end; col ++) {
         for(row = (row_start+trimTop); row < row_end - trimBottom; row ++) {
-            letter_img[k] = letter_img[(col-col_start)*letter_h +row];
+            pixel_buffer[k] = pixel_buffer[(col-col_start)*letter_h +row];
             k++;
         }
     }
 
 #if LV_ENABLE_CHARACTER_BUFFER != 0
     /* Draw the character image on the screen */
-    lv_disp_map(pos_p->y + trimTop, pos_p->x, pos_p->y + trimTop + (letter_h - trimTop - trimBottom), pos_p->x + letter_w,letter_img);
+    lv_disp_map(pos_p->y + trimTop, pos_p->x, pos_p->y + trimTop + (letter_h - trimTop - trimBottom), pos_p->x + letter_w,pixel_buffer);
 #endif
 }
 
@@ -302,19 +303,19 @@ void lv_rmap(const lv_area_t * cords_p, const lv_area_t * mask_p,
     } else {
         lv_color_t chroma_key_color = LV_COLOR_TRANSP;
         lv_coord_t col;
-        lv_color_t img_buffer[masked_a.x2 - masked_a.x1];
+        bzero(pixel_buffer, sizeof(pixel_buffer));
         for(row = masked_a.y1; row <= masked_a.y2; row++) {
             for(col = masked_a.x1; col <= masked_a.x2; col++) {
                 lv_color_t * px_color = (lv_color_t *) &map_p[(uint32_t)(col - masked_a.x1) * sizeof(lv_color_t)];
                 if(chroma_key && chroma_key_color.full == px_color->full) continue;
                 if(recolor_opa != LV_OPA_TRANSP) {
                     lv_color_t recolored_px = lv_color_mix(recolor, *px_color, recolor_opa);
-                    img_buffer[col - masked_a.x1] = recolored_px;
+                    pixel_buffer[col - masked_a.x1] = recolored_px;
                 } else {
-                    img_buffer[col - masked_a.x1] = *px_color;
+                    pixel_buffer[col - masked_a.x1] = *px_color;
                 }
             }
-            lv_disp_map(row, masked_a.x1, row+1, masked_a.x2, img_buffer);
+            lv_disp_map(row, masked_a.x1, row+1, masked_a.x2, pixel_buffer);
             map_p += map_width * sizeof(lv_color_t);               /*Next row on the map*/
         }
     }

--- a/lv_draw/lv_draw_rbasic.c
+++ b/lv_draw/lv_draw_rbasic.c
@@ -29,7 +29,7 @@
  *  STATIC VARIABLES
  **********************/
 static lv_color_t letter_bg_color;
-#if LV_ENABLE_CHARACTER_BUFFER != 0
+#if LV_ENABLE_PIXEL_BUFFER != 0
     static lv_color_t pixel_buffer[LV_CHARACTER_MAX_PIX_HEIGHT * LV_CHARACTER_MAX_PIX_WIDTH];
 #endif
 /**********************
@@ -122,7 +122,7 @@ void lv_rletter(const lv_point_t * pos_p, const lv_area_t * mask_p,
     uint8_t mask_init;
     uint8_t mask;
 
-#if LV_ENABLE_CHARACTER_BUFFER != 0
+#if LV_ENABLE_PIXEL_BUFFER != 0
 
     // Make sure letter dimensions don't exceed the size of our character buffer
     letter_h = (letter_h > LV_CHARACTER_MAX_PIX_HEIGHT) ? LV_CHARACTER_MAX_PIX_HEIGHT : letter_h;
@@ -190,7 +190,7 @@ void lv_rletter(const lv_point_t * pos_p, const lv_area_t * mask_p,
         for(col = col_start; col < col_end; col ++) {
             letter_px = (*map_p & mask) >> (8 - col_bit - bpp);
             if(letter_px != 0) {
-#if LV_ENABLE_CHARACTER_BUFFER == 0
+#if LV_ENABLE_PIXEL_BUFFER == 0
                 lv_rpx(pos_p->x + col, pos_p->y + row, mask_p, lv_color_mix(color, letter_bg_color, bpp == 8 ? letter_px : bpp_opa_table[letter_px]), LV_OPA_COVER);
                 zeroRow[row] = 0;
                 isWhitespace = false;
@@ -247,7 +247,7 @@ void lv_rletter(const lv_point_t * pos_p, const lv_area_t * mask_p,
         }
     }
 
-#if LV_ENABLE_CHARACTER_BUFFER != 0
+#if LV_ENABLE_PIXEL_BUFFER != 0
     /* Draw the character image on the screen */
     lv_disp_map(pos_p->y + trimTop, pos_p->x, pos_p->y + trimTop + (letter_h - trimTop - trimBottom), pos_p->x + letter_w,pixel_buffer);
 #endif


### PR DESCRIPTION
File: lv_draw/lv_draw_rbasic.c

Changed lv_rmap() to use lv_disp_map() instead of lv_rpx().

The call to map_fp() for boot splash display would normally take
1.3 seconds. Now the call to map_fp() takes 29 milliseconds.